### PR TITLE
Add ParseBytes func to Parser

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -57,6 +57,17 @@ func (parser *Parser) Parse(path string) error {
 	return parser.rt.run(string(contents))
 }
 
+// ParseBytes loads a proxy auto-config (PAC) file using the given byte array
+func (parser *Parser) ParseBytes(contents []byte) error {
+	if !parser.initialised {
+		if err := parser.init(); err != nil {
+			return err
+		}
+	}
+
+	return parser.rt.run(string(contents))
+}
+
 // ParseUrl downloads and parses a proxy auto-config (PAC) file using the given
 // URL returning an error if the file fails to load.
 func (parser *Parser) ParseUrl(url string) error {


### PR DESCRIPTION
Lovely little package.

I am looking to use this library in a project I am involved in, looks great. My only issue with it was that in my usecase, the PAC file is already loaded into memory as a `[]byte` and I didn't want to have to do an unnecessary file read or HTTP call to load the parser.

Warmest regards,
Benji
 