### PR TITLE
Removed default useragent header in ParseUrl http.GET

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -77,7 +77,7 @@ func (parser *Parser) ParseUrl(url string) error {
 		}
 	}
 
-        //prevent default UA from being sent
+        //prevent default UA from being sent (UA header is unnecessary and causes logging issues in some scenarios)
         client := &http.Client{}
         req, err := http.NewRequest("GET", url, nil)
 

--- a/parser.go
+++ b/parser.go
@@ -77,7 +77,12 @@ func (parser *Parser) ParseUrl(url string) error {
 		}
 	}
 
-	response, err := http.Get(url)
+        //prevent default UA from being sent
+        client := &http.Client{}
+        req, err := http.NewRequest("GET", url, nil)
+
+        req.Header.Set("User-Agent", "")
+        response, err := client.Do(req)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
ParseUrl uses http.get to pull the PAC, without defining headers. This sends a default "Go-http-client/1.1" header along with every request. The user agent header is unnecessary and in some cases creates logging issues. Add code to use client object instead and explicitly set user agent header to empty so that it does not get sent with every PAC request.